### PR TITLE
Hiera backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,59 @@
 # NSD
 
-    include nsd
+## Usage
+
+### Server Setup
+
+At minimum you only need to include the class nsd. The defaults
+are reasonable for running nsd on a stand-alone host. If you have
+it running in pair with unbound, you may want to set the port
+nsd listens on:
+
+```puppet
+    class { "nsd":
+      port => "5353",
+    }
+```
+
+### Remote Control
+
+The NSD remote controls the use of the nsd-control utility to
+issue commands to the NSD daemon process.
+
+```puppet
     include nsd::remote
+```
+
+### Zone configuration
+
+You can use hiera-file or the template directory to store your
+zone files that you want to have deployed to your NSD server.
+The default is to pick them up from the modules template directory.
+
+If you are using hiera, you may have the configuration like the
+following example, additionally to the rest of your NSD configuration,
+for one forward and one reverse zone:
+
+```
+    hiera
+      nsd_config:
+        templatestorage: hiera
+        zones:
+          intern:
+            template: 'intern.zone'
+          0.168.192.in-addr.arpa:
+            template: '0.168.192.in-addr.arpa.zone'
+```
+
+The templatestorage parameter tells puppet to lookup the files
+with hiera-file.
+
+```
+   puppet
+     $nsd_config = hiera_hash('nsd_config')
+     create_resources(nsd::zone, $nsd_config['zones'], { templatestorage => $nsd_config['templatestorage'] })
+```
+
+## Contribute
+
+Please help me make this module awesome!  Send pull requests and file issues.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ If you are using hiera, you may have the configuration like the
 following example, additionally to the rest of your NSD configuration,
 for one forward and one reverse zone:
 
-```
-    hiera
+```hiera
       nsd_config:
         templatestorage: hiera
         zones:
@@ -48,8 +47,7 @@ for one forward and one reverse zone:
 The templatestorage parameter tells puppet to lookup the files
 with hiera-file.
 
-```
-   puppet
+```puppet
      $nsd_config = hiera_hash('nsd_config')
      create_resources(nsd::zone, $nsd_config['zones'], { templatestorage => $nsd_config['templatestorage'] })
 ```

--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -17,7 +17,7 @@ class nsd::remote (
   $config_file = $nsd::params::config_file
 
   concat::fragment { 'nsd-remote':
-    order   => 10,
+    order   => '10',
     target  => $config_file,
     content => template('nsd/remote.erb'),
   }


### PR DESCRIPTION
    Allow the zone files to be retrieved from hiera-file, but default
    to the puppet templates directory.
    
    When creating a zone, add templatestorage => 'hiera'
    to make the module look up into hiera, otherwise, the default
    is 'puppet'.
