### PR TITLE
make dependencies on nsd-control runs require Service[nsd]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,12 +56,14 @@ class nsd (
   exec { 'nsd-control reload':
     command     => 'nsd-control reload',
     refreshonly => true,
+    require     => Service[$service_name],
     #notify      => Exec['nsd-control reconfig'],
   }
 
   exec { 'nsd-control reconfig':
     command     => 'nsd-control reconfig',
     refreshonly => true,
+    require     => Service[$service_name],
   }
 
   file { $zonedir:

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -5,11 +5,11 @@ define nsd::zone (
   $templatestorage = 'puppet',
 ) {
 
-  include nsd::params
+  include nsd
 
-  $config_file = $nsd::params::config_file
-  $owner       = $nsd::params::owner
-  $zonedir     = $nsd::params::zonedir
+  $config_file = $nsd::config_file
+  $owner       = $nsd::owner
+  $zonedir     = $nsd::zonedir
   $zonefile    = "${name}.zone"
 
   concat::fragment { "nsd-zone-${name}":
@@ -43,6 +43,6 @@ define nsd::zone (
   exec { "nsd-control reload ${name}":
     command     => "nsd-control reload ${name}",
     refreshonly => true,
-    require     => Concat[$config_file],
+    require     => [ Concat[$config_file], Service[$::nsd::service_name], ],
   }
 }


### PR DESCRIPTION
On initial deployment, those errors that nsd-control reload
of zones errored out, annoyed me since long time. I eventually
got around to tighten the dependency to the Service[nsd],
so that those are only triggered after that service is started.

at least, works for me now ;) more details below.
Let me know if you think something is wrong/needs enhancement...

Fixup zone.pp nsd-reload, to only act, after the service
is managed, i.e. in order to prevent reloads, before
nsd is running, i.e. make it depend on Service[$nsd::service_name].

Additionally, take parameters from $::nsd::PARAMNAME, instead of default
values from $::nsd::params::PARAMNAME. Therefore include nsd, instead
if include nsd::params

Similarily to zone.pp, make nsd-control reload and nsd-control reconfig
depend onService[$service_name]