### PR TITLE
Fix tests to include a dummy path

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class nsd::params {
       $service_name = 'nsd'
       $owner        = 'nsd'
       $group        = 'nsd'
+      $control_cmd  = 'nsd-control'
       $database     = '/var/db/nsd/nsd.db'
     }
     default: {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,6 +9,7 @@ openbsd_facts = {
   :id => 'root',
   :kernel => 'OpenBSD',
   :is_pe => false,
+  :path => "dummy",
 }
 
 freebsd_facts = {
@@ -18,6 +19,7 @@ freebsd_facts = {
   :id => 'root',
   :kernel => 'FreeBSD',
   :is_pe => false,
+  :path => "dummy",
 }
 
 


### PR DESCRIPTION
Fix the spec failure by adding a dummy path fact, and also fix a minor missing variable in params. I'm not sure if that's the correct setting for FreeBSD's nsd control command. (saw your messages on irc)