### PR TITLE
fix for OpenBSD wrt. package_name parameter

### DIFF
--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -1,6 +1,7 @@
 nsd::config_d: '/var/nsd/etc'
 nsd::config_file: '/var/nsd/etc/nsd.conf'
 nsd::zonedir: '/var/nsd/zones'
+nsd::package_name: ~
 nsd::service_name: 'nsd'
 nsd::owner: '_nsd'
 nsd::group: '_nsd'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@ class nsd (
   String $config_d,
   String $config_file,
   String $service_name,
-  String $package_name,
+  Variant[String,Undef] $package_name,
   String $control_cmd,
   String $zonedir,
   Boolean $zonepurge, # purge of unmanaged zone files


### PR DESCRIPTION
OpenBSD doesn't have a nsd package, therefore package_name might
not be given and no package needs to be installed.
Make the package_name Optional.